### PR TITLE
Support for 2.x-style Repository URLs

### DIFF
--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -1,7 +1,13 @@
 require 'spec_helper'
 
 def url(format, version)
-  "https://artifacts.elastic.co/packages/#{version}/#{format}"
+  case version
+  when %r{^2}
+    repo_type = (format == 'yum') ? 'centos' : 'debian'
+    "https://packages.elastic.co/elasticsearch/#{version}/#{repo_type}"
+  else
+    "https://artifacts.elastic.co/packages/#{version}/#{format}"
+  end
 end
 
 def declare_apt(version: '6.x', **params)
@@ -36,6 +42,19 @@ describe 'elastic_stack::repo', type: 'class' do
         it { is_expected.to declare_zypper }
         it { is_expected.to contain_exec('elastic_suse_import_gpg').with(command: rpm_key_cmd) }
         it { is_expected.to contain_exec('elastic_zypper_refresh_elastic').with(command: 'zypper refresh elastic') }
+      end
+
+      context 'with "version => 2"' do
+        let(:params) { default_params.merge(version: 2) }
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to declare_apt(version: '2.x') }
+        when 'RedHat'
+          it { is_expected.to declare_yum(version: '2.x') }
+        when 'Suse'
+          it { is_expected.to declare_zypper(version: '2.x') }
+        end
       end
 
       context 'with "version => 5"' do


### PR DESCRIPTION
I would _love_ to use this module in puppet-elasticsearch, but one minor capability that I'd lose is the ability to run 2.x versions of Elasticsearch. Yes, it's ancient, but it's not _technically_ out of the lifecycle support matrix yet, so this should be a fairly minor change to make it work - tests pass, there isn't a whole lot of ugly logic aside from checking the version number, so it seems reasonable to me. Thoughts?

Related to elastic/puppet-elasticsearch#906