### PR TITLE
Support 6.3 OSS repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - bundle -v
 
 script:
-  - 'bundle exec rake rubocop syntax validate lint spec'
+  - 'bundle exec rake test'
 
 matrix:
   fast_finish: true

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,11 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
+
+desc 'Run the test suite.'
+task :test => [
+  :rubocop,
+  :syntax,
+  :validate,
+  :lint,
+  :spec
+]

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -5,22 +5,26 @@
 # @example
 #   include elastic_stack::repo
 #
-# @param version The (major) version of the Elastic Stack for which to configure the repo
+# @param oss Whether to use the purely open source (i.e., bundled without X-Pack) repository
+# @param prerelease Whether to use a repo for prerelease versions, like "6.0.0-rc2"
 # @param priority A numeric priority for the repo, passed to the package management system
 # @param proxy The URL of a HTTP proxy to use for package downloads (YUM only)
-# @param prerelease Whether to use a repo for prerelease versions, like "6.0.0-rc2"
+# @param version The (major) version of the Elastic Stack for which to configure the repo
 class elastic_stack::repo(
-  Integer $version=6,
-  Optional[Integer] $priority=undef,
-  String $proxy='absent',
-  Boolean $prerelease=false,
+  Boolean           $oss        = false,
+  Boolean           $prerelease = false,
+  Optional[Integer] $priority   = undef,
+  String            $proxy      = 'absent',
+  Integer           $version    = 6,
 )
 
 {
   if $prerelease {
     $url_suffix = '-prerelease'
   }
-  else {
+  elsif $oss {
+    $url_suffix = '-oss'
+  } else {
     $url_suffix = ''
   }
 

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -96,6 +96,19 @@ describe 'elastic_stack::repo', type: 'class' do
         end
       end
 
+      context 'with "oss => true"' do
+        let(:params) { default_params.merge(oss: true) }
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to declare_apt(version: '6.x-oss') }
+        when 'RedHat'
+          it { is_expected.to declare_yum(version: '6.x-oss') }
+        when 'Suse'
+          it { is_expected.to declare_zypper(version: '6.x-oss') }
+        end
+      end
+
       context 'with proxy parameter' do
         let(:params) { default_params.merge(proxy: 'http://proxy.com:8080') }
 


### PR DESCRIPTION
This should contain the requisite changes to get OSS repositories conditionally enabled - it's been a while since I poked at it; so it may be worth independently verifying that the repo URL it constructs will be the correct path that'll be created upstream. 👍 