### PR TITLE
Update puppetlabs/apt dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     },
     {
       "name": "puppet/yum",


### PR DESCRIPTION
The new puppetlabs/apt version has fixes for Ubuntu 18.04