### PR TITLE
Allow the use of stdlib version 5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
Puppet's stdlib version 5 has been out for a while. Version conflicts from modules that require it have started [causing test failures for elastic/logstash](https://travis-ci.org/elastic/puppet-logstash/jobs/420702506#L887).

I propose we allow stdlib version 5 in all our modules, since the [breaking changes are actually very few](https://forge.puppet.com/puppetlabs/stdlib/changelog#supported-release-500).

Fixes #15