### PR TITLE
support 1.x version

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,14 +16,9 @@ class elastic_stack::repo (
   Boolean           $prerelease    = false,
   Optional[Integer] $priority      = undef,
   String            $proxy         = 'absent',
-  Integer           $version       = 6,
+  String            $version       = '6',
   Optional[String]  $base_repo_url = undef,
 ) {
-  if $prerelease {
-    $version_suffix = '.x-prerelease'
-  } else {
-    $version_suffix = '.x'
-  }
 
   if $oss {
     $version_prefix = 'oss-'
@@ -31,30 +26,59 @@ class elastic_stack::repo (
     $version_prefix = ''
   }
 
-  if $version > 2 {
-    $_repo_url = $base_repo_url ? {
-      undef   => 'https://artifacts.elastic.co/packages',
-      default => $base_repo_url,
-    }
-    case $facts['os']['family'] {
-      'Debian': {
-        $_repo_path = 'apt'
+  case $version {
+    default : {
+      if $prerelease {
+        $version_suffix = '.x-prerelease'
+      } else {
+        $version_suffix = '.x'
       }
-      default: {
-        $_repo_path = 'yum'
+      $_repo_url = $base_repo_url ? {
+        undef   => 'https://artifacts.elastic.co/packages',
+        default => $base_repo_url,
+      }
+      case $facts['os']['family'] {
+        'Debian': {
+          $_repo_path = 'apt'
+        }
+        default: {
+          $_repo_path = 'yum'
+        }
       }
     }
-  } else {
-    $_repo_url = $base_repo_url ? {
-      undef   => 'https://packages.elastic.co/elasticsearch',
-      default => $base_repo_url,
-    }
-    case $facts['os']['family'] {
-      'Debian': {
-        $_repo_path = 'debian'
+    /^2/: {
+      if $prerelease {
+        $version_suffix = '.x-prerelease'
+      } else {
+        $version_suffix = '.x'
       }
-      default: {
-        $_repo_path = 'centos'
+
+      $_repo_url = $base_repo_url ? {
+        undef   => 'https://packages.elastic.co/elasticsearch',
+        default => $base_repo_url,
+      }
+      case $facts['os']['family'] {
+        'Debian': {
+          $_repo_path = 'debian'
+        }
+        default: {
+          $_repo_path = 'centos'
+        }
+      }
+    }
+    /^1/: {
+      $version_suffix = ''
+      $_repo_url = $base_repo_url ? {
+        undef   => 'https://packages.elastic.co/elasticsearch',
+        default => $base_repo_url,
+      }
+      case $facts['os']['family'] {
+        'Debian': {
+          $_repo_path = 'debian'
+        }
+        default: {
+          $_repo_path = 'centos'
+        }
       }
     }
   }

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 def url(format, version)
   case version
-  when %r{^2}
+  when %r{^[1-2]}
     repo_type = (format == 'yum') ? 'centos' : 'debian'
     "https://packages.elastic.co/elasticsearch/#{version}/#{repo_type}"
   else
@@ -44,8 +44,21 @@ describe 'elastic_stack::repo', type: 'class' do
         it { is_expected.to contain_exec('elastic_zypper_refresh_elastic').with(command: 'zypper refresh elastic') }
       end
 
-      context 'with "version => 2"' do
-        let(:params) { default_params.merge(version: 2) }
+      context 'with "version => \'1.7\'"' do
+        let(:params) { default_params.merge(version: '1.7') }
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to declare_apt(version: '1.7') }
+        when 'RedHat'
+          it { is_expected.to declare_yum(version: '1.7') }
+        when 'Suse'
+          it { is_expected.to declare_zypper(version: '1.7') }
+        end
+      end
+
+      context 'with "version => \'2\'"' do
+        let(:params) { default_params.merge(version: '2') }
 
         case facts[:os]['family']
         when 'Debian'
@@ -57,8 +70,8 @@ describe 'elastic_stack::repo', type: 'class' do
         end
       end
 
-      context 'with "version => 5"' do
-        let(:params) { default_params.merge(version: 5) }
+      context 'with "version => \'5\'"' do
+        let(:params) { default_params.merge(version: '5') }
 
         case facts[:os]['family']
         when 'Debian'


### PR DESCRIPTION
Repos are not http://packages.elastic.co/elasticsearch/1.x/debian but 
http://packages.elastic.co/elasticsearch/1.7/debian (for example).

Problem is version is now a string (actually more relevant) and breaks compatibility.