### PR TITLE
Add forced exec of apt-get update to debian side

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -83,6 +83,11 @@ class elastic_stack::repo (
           'src' => false,
         },
         pin      => $priority,
+      }~>
+      exec { 'elastic_stack_apt_update':
+        command     => 'apt-get update',
+        path        => [ '/usr/bin', '/bin'],
+        refreshonly => true,
       }
     }
     'RedHat', 'Linux': {


### PR DESCRIPTION
Since the apt package doesn't force apt-get update when notified, but instead schedules it for somewhere in the run, this change forces apt-get update after adding the repository.
Without this change you sometimes need to run puppet twice, once to add the source and update (usually at end of puppet run) and again to actually install the packages.