### PR TITLE
Release 6.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Release 6.3.2
+ - Allow puppetlabs-apt version 7.x
+ - Allow puppetlabs-stdlib version 6.x
+ - Allow puppet-yum version 4.x
+ - Constrain puppetlabs-yumrepo_core to puppet 6+
+
 ## Release 6.3.1
 - Remove extraneous files from module package
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "elastic-elastic_stack",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "author": "toby@jarpy.net",
   "summary": "Helpers for installing and configuring components of the Elastic Stack.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bump version in `metadata.json` and add `CHANGELOG` entries in preperation for release of version 6.3.2 on Puppet Forge.