### PR TITLE
Add an optional key_source parameter to set up the package repository.

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,6 +18,7 @@ class elastic_stack::repo (
   String            $proxy         = 'absent',
   Integer           $version       = 7,
   Optional[String]  $base_repo_url = undef,
+  Optional[String]  $key_source    = 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
 ) {
   if $prerelease {
     $version_suffix = '.x-prerelease'
@@ -61,7 +62,6 @@ class elastic_stack::repo (
 
   $base_url = "${_repo_url}/${version_prefix}${version}${version_suffix}/${_repo_path}"
   $key_id='46095ACC8548582C1A2699A9D27D666CD88E42B4'
-  $key_source='https://artifacts.elastic.co/GPG-KEY-elasticsearch'
   $description='Elastic package repository.'
 
   case $::osfamily {


### PR DESCRIPTION
Our internal hosts have no access to the internet, hence no option to download GPG-KEY-elasticsearch. This tiny patch adds the option to specify the download location for the GPG file. 